### PR TITLE
feat: Guide-based Grid Layout

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -17,8 +17,8 @@ function ArrowIcon() {
 
 export default function Footer() {
   return (
-    <footer className="mb-16">
-      <ul className="font-sm mt-8 flex flex-col space-x-0 space-y-2 text-neutral-600 md:flex-row md:space-x-4 md:space-y-0 dark:text-neutral-300">
+    <footer>
+      <ul className="font-sm flex flex-col space-x-0 space-y-2 text-neutral-600 md:flex-row md:space-x-4 md:space-y-0 dark:text-neutral-400">
         <li>
           <a
             className="flex items-center transition-all hover:text-neutral-800 dark:hover:text-neutral-100"

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -27,7 +27,7 @@ export default function Footer() {
             href="https://github.com/hufort"
           >
             <ArrowIcon />
-            <p className="ml-2 h-7">github</p>
+            <p className="ml-2 h-7">GitHub</p>
           </a>
         </li>
         <li>
@@ -38,7 +38,7 @@ export default function Footer() {
             href="https://github.com/hufort/eigen"
           >
             <ArrowIcon />
-            <p className="ml-2 h-7">view source</p>
+            <p className="ml-2 h-7">View source</p>
           </a>
         </li>
       </ul>

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -1,12 +1,21 @@
+'use client'
+
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { cn } from '@/utils'
 
 const navItems = {
+  '/': {
+    name: 'Hey',
+  },
   '/notebook': {
-    name: 'notebook',
+    name: 'Notes',
   },
 }
 
 export function Navbar() {
+  const pathname = usePathname()
+
   return (
     <aside className="-ml-[8px] mb-16 tracking-tight">
       <div className="lg:sticky lg:top-20">
@@ -16,11 +25,17 @@ export function Navbar() {
         >
           <div className="flex flex-row space-x-0 pr-10">
             {Object.entries(navItems).map(([path, { name }]) => {
+              const isActive = pathname === path
               return (
                 <Link
                   key={path}
                   href={path}
-                  className="transition-all hover:text-neutral-800 dark:hover:text-neutral-200 flex align-middle relative py-1 px-2 m-1"
+                  className={cn(
+                    'transition-all hover:text-neutral-800 dark:hover:text-neutral-200 flex align-middle relative py-1 px-2 m-1 font-medium ',
+                    isActive
+                      ? 'text-neutral-800 dark:text-neutral-300'
+                      : 'text-neutral-600 dark:text-neutral-400'
+                  )}
                 >
                   {name}
                 </Link>

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -17,13 +17,13 @@ export function Navbar() {
   const pathname = usePathname()
 
   return (
-    <aside className="-ml-[8px] mb-16 tracking-tight">
+    <aside className="tracking-tight">
       <div className="lg:sticky lg:top-20">
         <nav
           className="flex flex-row items-start relative px-0 pb-0 fade md:overflow-auto scroll-pr-6 md:relative"
           id="nav"
         >
-          <div className="flex flex-row space-x-0 pr-10">
+          <div className="flex flex-row space-x-0">
             {Object.entries(navItems).map(([path, { name }]) => {
               const isActive = pathname === path
               return (

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -17,7 +17,7 @@ export function Navbar() {
   const pathname = usePathname()
 
   return (
-    <aside className="tracking-tight">
+    <aside className="-ml-3 tracking-tight">
       <div className="lg:sticky lg:top-20">
         <nav
           className="flex flex-row items-start relative px-0 pb-0 fade md:overflow-auto scroll-pr-6 md:relative"

--- a/app/global.css
+++ b/app/global.css
@@ -104,7 +104,7 @@ html {
 }
 
 .prose strong {
-  @apply font-medium;
+  @apply font-bold;
 }
 
 .prose ul {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -102,7 +102,7 @@ export default function RootLayout({
             <div
               className={cn(
                 SECTION_PADDING,
-                'border-l border-t border-dashed border-stone-300 dark:border-sky-300/10 md:col-start-2 overflow-y-auto flex-1'
+                'md:border-l border-t border-dashed border-stone-300 dark:border-sky-300/10 md:col-start-2 overflow-y-auto flex-1'
               )}
             >
               {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -64,6 +64,8 @@ export const metadata: Metadata = {
   },
 }
 
+const SECTION_PADDING = 'p-8 sm:py-10 lg:p-12'
+
 export default function RootLayout({
   children,
 }: {
@@ -81,19 +83,34 @@ export default function RootLayout({
       <body className="antialiased h-full">
         <main className="grid grid-rows-[auto_1fr] md:grid-rows-[1fr_3fr] h-full w-full">
           <div className="grid grid-cols-[1fr_auto] md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full">
-            <div className="px-12 py-16 md:col-start-1">
+            <div className={cn(SECTION_PADDING, 'md:col-start-1')}>
               <AnimatedLogo size={40} />
             </div>
-            <div className="md:border-l border-dashed border-stone-300 dark:border-sky-300/10 px-12 py-16 md:col-start-2">
+            <div
+              className={cn(
+                SECTION_PADDING,
+                'md:border-l border-dashed border-stone-300 dark:border-sky-300/10 md:col-start-2'
+              )}
+            >
               <Navbar />
             </div>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full grid-flow-dense">
-            <div className="border-l border-t border-dashed border-stone-300 dark:border-sky-300/10 px-12 py-16 md:col-start-2">
+            <div
+              className={cn(
+                SECTION_PADDING,
+                'border-l border-t border-dashed border-stone-300 dark:border-sky-300/10  md:col-start-2'
+              )}
+            >
               {children}
             </div>
-            <div className="border-t border-dashed border-stone-300 dark:border-sky-300/10 px-12 py-16 flex items-end md:col-start-1">
+            <div
+              className={cn(
+                SECTION_PADDING,
+                'border-t border-dashed border-stone-300 dark:border-sky-300/10 flex items-end md:col-start-1'
+              )}
+            >
               <Footer />
             </div>
           </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -73,18 +73,27 @@ export default function RootLayout({
     <html
       lang="en"
       className={cn(
-        'text-stone-700 bg-stone-200 dark:text-neutral-300 dark:bg-sky-400/05',
+        'text-stone-700 bg-stone-200 dark:text-neutral-300 dark:bg-sky-400/05 h-screen',
         GeistSans.variable,
         GeistMono.variable
       )}
     >
-      <body className="antialiased max-w-xl mx-4 mt-8 lg:mx-auto">
-        <main className="flex-auto min-w-0 mt-12 flex flex-col px-2 md:px-0">
-          <div className="mb-8">
-            <AnimatedLogo size={40} />
+      <body className="antialiased h-full">
+        <main className="flex-auto min-w-0 flex flex-col h-full w-full">
+          <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full md:grid-rows-[1fr_3fr]">
+            <div className="mb-8 px-12 py-16 md:col-start-1">
+              <AnimatedLogo size={40} />
+            </div>
+            <div className="border-l border-dashed border-stone-300 dark:border-sky-300/10 px-12 py-16 md:col-start-2">
+              <Navbar />
+            </div>
+            <div className="border-l border-t border-dashed border-stone-300 dark:border-sky-300/10 px-12 py-16 md:col-start-2">
+              {children}
+            </div>
+            <div className="border-t border-dashed border-stone-300 dark:border-sky-300/10 px-12 py-16 flex items-end md:col-start-1 md:row-start-2">
+              <Footer />
+            </div>
           </div>
-          {children}
-          <Footer />
           <Analytics />
           <SpeedInsights />
         </main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -80,8 +80,8 @@ export default function RootLayout({
         GeistMono.variable
       )}
     >
-      <body className="antialiased h-screen">
-        <main className="grid grid-rows-[auto_1fr] md:grid-rows-[1fr_4fr] h-full w-full min-h-0">
+      <body className="antialiased md:h-screen h-min-screen">
+        <main className="grid grid-rows-[auto_1fr] md:grid-rows-[1fr_4fr] h-full w-full min-h-screen md:min-h-0">
           {/* Top section */}
           <div className="grid grid-cols-[1fr_auto] md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full">
             <div className={cn(SECTION_PADDING, 'md:col-start-1')}>
@@ -98,11 +98,11 @@ export default function RootLayout({
           </div>
 
           {/* bottom section */}
-          <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full grid-flow-dense min-h-0">
+          <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full grid-flow-dense min-h-0 grid-rows-[1fr_auto]">
             <div
               className={cn(
                 SECTION_PADDING,
-                'border-l border-t border-dashed border-stone-300 dark:border-sky-300/10 md:col-start-2 overflow-y-auto'
+                'border-l border-t border-dashed border-stone-300 dark:border-sky-300/10 md:col-start-2 overflow-y-auto flex-1'
               )}
             >
               {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -79,21 +79,25 @@ export default function RootLayout({
       )}
     >
       <body className="antialiased h-full">
-        <main className="flex-auto min-w-0 flex flex-col h-full w-full">
-          <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full md:grid-rows-[1fr_3fr]">
-            <div className="mb-8 px-12 py-16 md:col-start-1">
+        <main className="grid grid-rows-[auto_1fr] md:grid-rows-[1fr_3fr] h-full w-full">
+          <div className="grid grid-cols-[1fr_auto] md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full">
+            <div className="px-12 py-16 md:col-start-1">
               <AnimatedLogo size={40} />
             </div>
-            <div className="border-l border-dashed border-stone-300 dark:border-sky-300/10 px-12 py-16 md:col-start-2">
+            <div className="md:border-l border-dashed border-stone-300 dark:border-sky-300/10 px-12 py-16 md:col-start-2">
               <Navbar />
             </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full grid-flow-dense">
             <div className="border-l border-t border-dashed border-stone-300 dark:border-sky-300/10 px-12 py-16 md:col-start-2">
               {children}
             </div>
-            <div className="border-t border-dashed border-stone-300 dark:border-sky-300/10 px-12 py-16 flex items-end md:col-start-1 md:row-start-2">
+            <div className="border-t border-dashed border-stone-300 dark:border-sky-300/10 px-12 py-16 flex items-end md:col-start-1">
               <Footer />
             </div>
           </div>
+
           <Analytics />
           <SpeedInsights />
         </main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -75,13 +75,14 @@ export default function RootLayout({
     <html
       lang="en"
       className={cn(
-        'text-stone-700 bg-stone-200 dark:text-neutral-300 dark:bg-sky-400/05 h-screen',
+        'text-stone-700 bg-stone-200 dark:text-neutral-300 dark:bg-sky-400/05',
         GeistSans.variable,
         GeistMono.variable
       )}
     >
-      <body className="antialiased h-full">
-        <main className="grid grid-rows-[auto_1fr] md:grid-rows-[1fr_3fr] h-full w-full">
+      <body className="antialiased h-screen">
+        <main className="grid grid-rows-[auto_1fr] md:grid-rows-[1fr_4fr] h-full w-full min-h-0">
+          {/* Top section */}
           <div className="grid grid-cols-[1fr_auto] md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full">
             <div className={cn(SECTION_PADDING, 'md:col-start-1')}>
               <AnimatedLogo size={40} />
@@ -96,11 +97,12 @@ export default function RootLayout({
             </div>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full grid-flow-dense">
+          {/* bottom section */}
+          <div className="grid grid-cols-1 md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full grid-flow-dense min-h-0">
             <div
               className={cn(
                 SECTION_PADDING,
-                'border-l border-t border-dashed border-stone-300 dark:border-sky-300/10  md:col-start-2'
+                'border-l border-t border-dashed border-stone-300 dark:border-sky-300/10 md:col-start-2 overflow-y-auto'
               )}
             >
               {children}

--- a/app/notebook/notes/0001-metaphors-of-our-time.mdx
+++ b/app/notebook/notes/0001-metaphors-of-our-time.mdx
@@ -5,10 +5,12 @@ summary: 'A quote from Meghan O'Gieblyn'
 ---
 
 > To discover truth, it is necessary to work within the metaphors of our own time, which are for the most part technological.
+>
 > Today artificial intelligence and information technologies have absorbed many of the questions that were once taken up by
 > theologians and philosophers: the mind’s relationship to the body, the question of free will, the possibility of immortality.
 > These are old problems, and although they now appear in different guises and go by different names, they persist in conversations
-> about digital technologies much like those dead metaphors that still lurk in the syntax of contemporary speech. All the eternal
-> questions have become engineering problems.
+> about digital technologies much like those dead metaphors that still lurk in the syntax of contemporary speech.
+>
+> All the eternal questions have become engineering problems.
 >
 > — [Meghan O'Gieblyn](https://www.meghanogieblyn.com/)

--- a/app/notebook/notes/0002-self-directed-idea.mdx
+++ b/app/notebook/notes/0002-self-directed-idea.mdx
@@ -1,0 +1,41 @@
+---
+title: 'A self-directed idea'
+publishedAt: '2024-12-11'
+summary: 'A quote from Meghan O'Gieblyn'
+---
+
+_I am laying on a massage table when this idea starts to unfold in front of me._
+
+It comes about as I notice how odd a collection of parts my body is. The masseuse presses on my right hip and I become aware of the interaction of connected pieces - hip, leg, back, muscles, bones, sockets, tendons - me.
+
+All **parts** of me. None of them me.
+
+Yet, I am not completely **me** without any one of them.
+
+Remove a fingernail from my left hand, or a finger, or the hand itself, and I wouldn’t say I am any less me. But the sum total my experience of self is, at that point, objectively different than it is with those pieces. Non-normative, but certainly non-null.
+
+I will never draw my hand across the surface of the ocean or feel the breeze across a fresh paper cut in the webbing of my thumb.
+
+I think this says something interesting about the notion of the hard problem.
+
+From a computational sense, it is no more possible for me to know, conclusively, what it is like to be a bat than to know what it is like to be me without a finger.
+
+But this does not mean that the subjective first person perspective is something spooky and unknowable, it is just that it can only be implemented as a singleton.
+
+The subjective experience can only ever be experienced in a unitary state. If we were to feel the exact same thing we would need to be the same instance.
+
+The platonic form of Love/Sadness/Transcendence/Suffering (insert any phenomenal notion) doesn’t matter. It does not exist at all beyond the shared aspects of our idealogical specification. But it can be implemented to some degree of granularity in our problem space. These coarse-grained instances of the concept are what actually exist (at least in the sense of res cogitans existence).
+
+And in bringing to bear this existence, the thing that truly matters to us arises.
+
+A computational paradigm seems to suggest that since these subjective experiences certainly seem to exist that they inherently have specifications.
+
+The implementation is an instance of the specification (on a particular substrate).
+
+In the substrate of spacetime (or whatever underlies that), I am that implementation -> specification -> idea.
+
+And so is everything else.
+
+The fascinating dynamic that separates the idea-that-is-me from the idea-that-is-a-rock is the loop that affords the me-idea to be aware of the me-idea.
+
+This self-referential loop seems to introduce the ability for the idea to influence itself, to evolve.

--- a/app/notebook/notes/0002-self-directed-idea.mdx
+++ b/app/notebook/notes/0002-self-directed-idea.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'A self-directed idea'
 publishedAt: '2024-12-11'
-summary: 'A quote from Meghan O'Gieblyn'
+summary: 'An reflection on the idea of subjective experience through the lens of computation'
 ---
 
 _I am laying on a massage table when this idea starts to unfold in front of me._

--- a/app/notebook/notes/0002-self-directed-idea.mdx
+++ b/app/notebook/notes/0002-self-directed-idea.mdx
@@ -16,26 +16,24 @@ Remove a fingernail from my left hand, or a finger, or the hand itself, and I wo
 
 I will never draw my hand across the surface of the ocean or feel the breeze across a fresh paper cut in the webbing of my thumb.
 
-I think this says something interesting about the notion of the hard problem.
-
-From a computational sense, it is no more possible for me to know, conclusively, what it is like to be a bat than to know what it is like to be me without a finger.
+I think this says something interesting about the notion of the hard problem — it is no more possible for me to fully know [what it is like to be a bat](https://www.sas.upenn.edu/~cavitch/pdf-library/Nagel_Bat.pdf) than to know what it is like to be me without a finger.
 
 But this does not mean that the subjective first person perspective is something spooky and unknowable, it is just that it can only be implemented as a singleton.
 
 The subjective experience can only ever be experienced in a unitary state. If we were to feel the exact same thing we would need to be the same instance.
 
-The platonic form of Love/Sadness/Transcendence/Suffering (insert any phenomenal notion) doesn’t matter. It does not exist at all beyond the shared aspects of our idealogical specification. But it can be implemented to some degree of granularity in our problem space. These coarse-grained instances of the concept are what actually exist (at least in the sense of res cogitans existence).
+The platonic form of Love/Sadness/Transcendence/Suffering (insert any phenomenal notion) doesn’t matter. It does not exist at all beyond the shared aspects of our idealogical specification. But it can be implemented to some degree in our problem space. These coarse-grained instances of the concept are what actually exist.
 
 And in bringing to bear this existence, the thing that truly matters to us arises.
 
 A computational paradigm seems to suggest that since these subjective experiences certainly seem to exist that they inherently have specifications.
 
-The implementation is an instance of the specification (on a particular substrate).
+The instance is animplementation of the specification (on a particular substrate).
 
-In the substrate of spacetime (or whatever underlies that), I am that implementation -> specification -> idea.
+In the substrate of spacetime (or whatever underlies that), I am the instance of an implementation -> specification -> idea.
 
 And so is everything else.
 
 The fascinating dynamic that separates the idea-that-is-me from the idea-that-is-a-rock is the loop that affords the me-idea to be aware of the me-idea.
 
-This self-referential loop seems to introduce the ability for the idea to influence itself, to evolve.
+It's this self-referential loop that seems to introduce the ability for an idea to influence itself, to evolve, to self-direct.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,9 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "baseUrl": ".",
+    "paths": {
+      "@/*": ["./app/*"]
+    },
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
# Guide-based Grid Layout

## Changes
This PR introduces a new layout system using a grid visual guidelines, somewhat inspired by traditional editorial aesthetics. The layout:
- Divides the viewport into distinct sections using dashed guidelines
- Maintains proper spacing and alignment across breakpoints
- Ensures footer placement remains consistent with minimal content
- Improves responsive behavior for both desktop and mobile views

### Additional Changes
- Added paths alias to tsconfig for cleaner imports
- Included new note on the virtual nature of self

## Demo
![CleanShot 2024-12-13 at 09 03 56@2x](https://github.com/user-attachments/assets/bf529734-d3ec-4caa-b935-52d0ea8fba95)
![CleanShot 2024-12-13 at 09 05 51@2x](https://github.com/user-attachments/assets/d67deb1c-da44-49df-84a8-660b40c968ed)
