### PR TITLE
feat: iOS Status Bar and Dynamic Viewport Improvements

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -18,10 +18,10 @@ function ArrowIcon() {
 export default function Footer() {
   return (
     <footer>
-      <ul className="font-sm flex flex-col space-x-0 space-y-2 text-neutral-600 md:flex-row md:space-x-4 md:space-y-0 dark:text-neutral-400">
+      <ul className="font-sm flex flex-col space-x-0 space-y-2 text-zinc-600 md:flex-row md:space-x-4 md:space-y-0 dark:text-zinc-400">
         <li>
           <a
-            className="flex items-center transition-all hover:text-neutral-800 dark:hover:text-neutral-100"
+            className="flex items-center transition-all hover:text-zinc-800 dark:hover:text-zinc-100"
             rel="noopener noreferrer"
             target="_blank"
             href="https://github.com/hufort"
@@ -32,7 +32,7 @@ export default function Footer() {
         </li>
         <li>
           <a
-            className="flex items-center transition-all hover:text-neutral-800 dark:hover:text-neutral-100"
+            className="flex items-center transition-all hover:text-zinc-800 dark:hover:text-zinc-100"
             rel="noopener noreferrer"
             target="_blank"
             href="https://github.com/hufort/eigen"

--- a/app/components/mdx.tsx
+++ b/app/components/mdx.tsx
@@ -88,7 +88,7 @@ function createHeading(level) {
 
 function Blockquote({ children }) {
   return (
-    <blockquote className="my-4 border-l-4 border-stone-300 pl-4 dark:border-neutral-700">
+    <blockquote className="my-4 border-l-4 border-stone-300 pl-4 dark:border-zinc-700">
       {children}
     </blockquote>
   )

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -31,10 +31,10 @@ export function Navbar() {
                   key={path}
                   href={path}
                   className={cn(
-                    'transition-all hover:text-neutral-800 dark:hover:text-neutral-200 flex align-middle relative py-1 px-2 m-1 font-medium ',
+                    'transition-all hover:text-zinc-800 dark:hover:text-zinc-200 flex align-middle relative py-1 px-2 m-1 font-medium ',
                     isActive
-                      ? 'text-neutral-800 dark:text-neutral-300'
-                      : 'text-neutral-600 dark:text-neutral-400'
+                      ? 'text-zinc-800 dark:text-zinc-300'
+                      : 'text-zinc-600 dark:text-zinc-400'
                   )}
                 >
                   {name}

--- a/app/components/notes.tsx
+++ b/app/components/notes.tsx
@@ -22,10 +22,10 @@ export function NotebookNotes() {
             href={`/notebook/${note.slug}`}
           >
             <div className="w-full flex flex-col md:flex-row space-x-0 md:space-x-2 items-baseline">
-              <p className="text-neutral-600 dark:text-neutral-400 w-10 font-mono text-sm">
+              <p className="text-zinc-600 dark:text-zinc-400 w-10 font-mono text-sm">
                 {note.noteNumber}
               </p>
-              <p className="text-neutral-900 dark:text-neutral-200 tracking-tight">
+              <p className="text-zinc-900 dark:text-zinc-200 tracking-tight">
                 {note.metadata.title}
               </p>
             </div>

--- a/app/global.css
+++ b/app/global.css
@@ -61,7 +61,7 @@ html {
 }
 
 .prose pre {
-  @apply bg-stone-200 dark:bg-sky-400/05 rounded-lg overflow-x-auto border border-stone-300 dark:border-sky-400/0.5 py-2 px-3 text-sm;
+  @apply bg-stone-200 dark:bg-zinc-400/05 rounded-lg overflow-x-auto border border-stone-300 dark:border-zinc-400/0.5 py-2 px-3 text-sm;
 }
 
 .prose code {
@@ -84,7 +84,7 @@ html {
 }
 
 .prose p {
-  @apply my-4 text-neutral-700 dark:text-neutral-300;
+  @apply my-4 text-zinc-700 dark:text-zinc-300;
 }
 
 .prose h1 {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,7 @@ import { cn } from './utils'
 export const viewport: Viewport = {
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: '#D6D3D1' }, // stone-300
-    { media: '(prefers-color-scheme: dark)', color: '#082F49' }, // sky-950
+    { media: '(prefers-color-scheme: dark)', color: '#09090B' }, // zinc-950
   ],
 }
 
@@ -82,7 +82,7 @@ export default function RootLayout({
     <html
       lang="en"
       className={cn(
-        'text-stone-700 bg-stone-200 dark:text-neutral-300 dark:bg-sky-400/05',
+        'text-stone-700 bg-stone-200 dark:text-zinc-300 dark:bg-zinc-800',
         GeistSans.variable,
         GeistMono.variable
       )}
@@ -97,7 +97,7 @@ export default function RootLayout({
             <div
               className={cn(
                 SECTION_PADDING,
-                'md:border-l border-dashed border-stone-300 dark:border-sky-300/10 md:col-start-2'
+                'md:border-l border-dashed border-stone-300 dark:border-zinc-300/10 md:col-start-2'
               )}
             >
               <Navbar />
@@ -109,7 +109,7 @@ export default function RootLayout({
             <div
               className={cn(
                 SECTION_PADDING,
-                'md:border-l border-t border-dashed border-stone-300 dark:border-sky-300/10 md:col-start-2 overflow-y-auto flex-1'
+                'md:border-l border-t border-dashed border-stone-300 dark:border-zinc-300/10 md:col-start-2 overflow-y-auto flex-1'
               )}
             >
               {children}
@@ -117,7 +117,7 @@ export default function RootLayout({
             <div
               className={cn(
                 SECTION_PADDING,
-                'border-t border-dashed border-stone-300 dark:border-sky-300/10 flex items-end md:col-start-1'
+                'border-t border-dashed border-stone-300 dark:border-zinc-300/10 flex items-end md:col-start-1'
               )}
             >
               <Footer />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import './global.css'
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
 import { Navbar } from './components/nav'
@@ -9,6 +9,13 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 import Footer from './components/footer'
 import { baseUrl } from './sitemap'
 import { cn } from './utils'
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#F5F5F4' }, // stone-200
+    { media: '(prefers-color-scheme: dark)', color: '#0C4A6E' }, // sky-900
+  ],
+}
 
 export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,7 @@ import { cn } from './utils'
 export const viewport: Viewport = {
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: '#D6D3D1' }, // stone-300
-    { media: '(prefers-color-scheme: dark)', color: '#09090B' }, // zinc-950
+    { media: '(prefers-color-scheme: dark)', color: '#27272A' }, // zinc-800
   ],
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -87,8 +87,8 @@ export default function RootLayout({
         GeistMono.variable
       )}
     >
-      <body className="antialiased md:h-screen h-min-screen">
-        <main className="grid grid-rows-[auto_1fr] md:grid-rows-[1fr_4fr] h-full w-full min-h-screen md:min-h-0">
+      <body className="antialiased md:h-[100dvh] h-min-[100dvh]">
+        <main className="grid grid-rows-[auto_1fr] md:grid-rows-[1fr_4fr] h-full w-full min-h-[100dvh] md:min-h-0">
           {/* Top section */}
           <div className="grid grid-cols-[1fr_auto] md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr] h-full">
             <div className={cn(SECTION_PADDING, 'md:col-start-1')}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,8 +12,8 @@ import { cn } from './utils'
 
 export const viewport: Viewport = {
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#F5F5F4' }, // stone-200
-    { media: '(prefers-color-scheme: dark)', color: '#0C4A6E' }, // sky-900
+    { media: '(prefers-color-scheme: light)', color: '#D6D3D1' }, // stone-300
+    { media: '(prefers-color-scheme: dark)', color: '#082F49' }, // sky-950
   ],
 }
 


### PR DESCRIPTION
# iOS Status Bar and Dynamic Viewport Improvements

## Changes
1. Added theme color support for iOS status bar
   - Light mode: stone-200
   - Dark mode: zinc-800
   - Configured via Next.js viewport export

2. Improved viewport height handling
   - Replaced `vh`/`screen` units with `dvh`
   - Better handles dynamic viewport changes on mobile
   - Accounts for browser UI elements like address bars