### PR TITLE
feat: footer link icons

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,44 +1,29 @@
-function ArrowIcon() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M2.07102 11.3494L0.963068 10.2415L9.2017 1.98864H2.83807L2.85227 0.454545H11.8438V9.46023H10.2955L10.3097 3.09659L2.07102 11.3494Z"
-        fill="currentColor"
-      />
-    </svg>
-  )
-}
+import { ArrowUpRight } from 'lucide-react'
 
 export default function Footer() {
   return (
     <footer>
-      <ul className="font-sm flex flex-col space-y-2 space-x-0 text-zinc-600 md:flex-row md:space-y-0 md:space-x-4 dark:text-zinc-400">
+      <ul className="font-sm flex flex-col space-y-2 space-x-0 text-zinc-600 lg:flex-row lg:space-y-0 lg:space-x-4 dark:text-zinc-400">
         <li>
           <a
-            className="flex items-center transition-all hover:text-zinc-800 dark:hover:text-zinc-100"
+            className="flex items-center text-sm transition-all hover:text-zinc-800 dark:hover:text-zinc-100"
             rel="noopener noreferrer"
             target="_blank"
             href="https://github.com/hufort"
           >
-            <ArrowIcon />
-            <p className="ml-2 h-7">GitHub</p>
+            <ArrowUpRight size={16} />
+            <p className="ml-1">GitHub</p>
           </a>
         </li>
         <li>
           <a
-            className="flex items-center transition-all hover:text-zinc-800 dark:hover:text-zinc-100"
+            className="flex items-center text-sm transition-all hover:text-zinc-800 dark:hover:text-zinc-100"
             rel="noopener noreferrer"
             target="_blank"
             href="https://github.com/hufort/eigen"
           >
-            <ArrowIcon />
-            <p className="ml-2 h-7">View source</p>
+            <ArrowUpRight size={16} />
+            <p className="ml-1">Source</p>
           </a>
         </li>
       </ul>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -90,7 +90,7 @@ export default function RootLayout({
       <body className="h-min-[100dvh] antialiased md:h-[100dvh]">
         <main className="grid h-full min-h-[100dvh] w-full grid-rows-[auto_1fr] md:min-h-0 md:grid-rows-[1fr_4fr]">
           {/* Top section */}
-          <div className="grid h-full grid-cols-[1fr_auto] md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr]">
+          <div className="grid h-full grid-cols-[1fr_auto] md:grid-cols-[1fr_3fr] xl:grid-cols-[3fr_2fr]">
             <div className={cn(SECTION_PADDING, 'md:col-start-1')}>
               <AnimatedLogo size={40} />
             </div>
@@ -105,7 +105,7 @@ export default function RootLayout({
           </div>
 
           {/* bottom section */}
-          <div className="grid h-full min-h-0 grid-flow-dense grid-cols-1 grid-rows-[1fr_auto] md:grid-cols-[2fr_3fr] xl:grid-cols-[3fr_2fr]">
+          <div className="grid h-full min-h-0 grid-flow-dense grid-cols-1 grid-rows-[1fr_auto] md:grid-cols-[1fr_3fr] xl:grid-cols-[3fr_2fr]">
             <div
               className={cn(
                 SECTION_PADDING,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vercel/speed-insights": "^1.0.9",
     "clsx": "^2.1.1",
     "geist": "1.2.2",
+    "lucide-react": "^0.468.0",
     "next": "canary",
     "next-mdx-remote": "^4.4.1",
     "postcss": "^8.4.35",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       geist:
         specifier: 1.2.2
         version: 1.2.2(next@14.2.0-canary.62(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      lucide-react:
+        specifier: ^0.468.0
+        version: 0.468.0(react@18.2.0)
       next:
         specifier: canary
         version: 14.2.0-canary.62(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -504,6 +507,11 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lucide-react@0.468.0:
+    resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
   markdown-extensions@1.1.1:
     resolution: {integrity: sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==}
@@ -1266,6 +1274,10 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lucide-react@0.468.0(react@18.2.0):
+    dependencies:
+      react: 18.2.0
 
   markdown-extensions@1.1.1: {}
 


### PR DESCRIPTION
- Use `lucide-react` icons
- Stack footer links until `xl` viewport
- Reduce width ratio of the 1st column (footer) on `md`/`lg` viewports