### PR TITLE
feat: make logo touch interaction interruptible

### DIFF
--- a/app/components/animated-logo.tsx
+++ b/app/components/animated-logo.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import Link from 'next/link'
 import { Logo } from './logo'
 import { cn } from '../utils'
@@ -8,6 +8,7 @@ import { cn } from '../utils'
 export function AnimatedLogo({ size = 40 }: { size?: number }) {
   const [isTransformed, setIsTransformed] = useState(false)
   const [isTouchDevice, setIsTouchDevice] = useState(false)
+  const timeoutRef = useRef<NodeJS.Timeout>()
 
   return (
     <Link
@@ -21,10 +22,15 @@ export function AnimatedLogo({ size = 40 }: { size?: number }) {
       onMouseEnter={() => !isTouchDevice && setIsTransformed(!isTransformed)}
       onTouchStart={() => {
         setIsTouchDevice(true)
-        setIsTransformed(true)
-        setTimeout(() => {
+        if (isTransformed) {
+          if (timeoutRef.current) clearTimeout(timeoutRef.current)
           setIsTransformed(false)
-        }, 2000)
+        } else {
+          setIsTransformed(true)
+          timeoutRef.current = setTimeout(() => {
+            setIsTransformed(false)
+          }, 2000)
+        }
       }}
     >
       <Logo

--- a/app/components/animated-logo.tsx
+++ b/app/components/animated-logo.tsx
@@ -5,9 +5,10 @@ import Link from 'next/link'
 import { Logo } from './logo'
 import { cn } from '../utils'
 
+const isTouchDevice = typeof window !== 'undefined' && 'ontouchstart' in window
+
 export function AnimatedLogo({ size = 40 }: { size?: number }) {
   const [isTransformed, setIsTransformed] = useState(false)
-  const [isTouchDevice, setIsTouchDevice] = useState(false)
   const timeoutRef = useRef<NodeJS.Timeout>()
 
   return (
@@ -21,15 +22,12 @@ export function AnimatedLogo({ size = 40 }: { size?: number }) {
       )}
       onMouseEnter={() => !isTouchDevice && setIsTransformed(!isTransformed)}
       onTouchStart={() => {
-        setIsTouchDevice(true)
         if (isTransformed) {
           if (timeoutRef.current) clearTimeout(timeoutRef.current)
           setIsTransformed(false)
         } else {
           setIsTransformed(true)
-          timeoutRef.current = setTimeout(() => {
-            setIsTransformed(false)
-          }, 2000)
+          timeoutRef.current = setTimeout(() => setIsTransformed(false), 2000)
         }
       }}
     >

--- a/app/components/animated-logo.tsx
+++ b/app/components/animated-logo.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import Link from 'next/link'
 import { Logo } from './logo'
 import { cn } from '../utils'
@@ -10,6 +10,12 @@ const isTouchDevice = typeof window !== 'undefined' && 'ontouchstart' in window
 export function AnimatedLogo({ size = 40 }: { size?: number }) {
   const [isTransformed, setIsTransformed] = useState(false)
   const timeoutRef = useRef<NodeJS.Timeout>()
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [])
 
   return (
     <Link


### PR DESCRIPTION
Added touch event handling to the animated logo component that:
- Detects touch capability once at module load
- Toggles transform state on tap with 2s auto-reset
- Allows interrupting animation with second tap
- Preserves hover behavior for non-touch devices